### PR TITLE
Bug Fix and Oracle support improvements

### DIFF
--- a/codjo-database-common/pom.xml
+++ b/codjo-database-common/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <!-- POM's layout - http://www.javaworld.com/javaworld/jw-05-2006/jw-0529-maven.html -->
 
     <modelVersion>4.0.0</modelVersion>
@@ -17,6 +18,7 @@
         <dependency>
             <groupId>net.codjo.fake-db</groupId>
             <artifactId>codjo-fake-db</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>picocontainer</groupId>

--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/JdbcFixture.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/JdbcFixture.java
@@ -1,10 +1,4 @@
 package net.codjo.database.common.api;
-import net.codjo.database.common.api.DatabaseQueryHelper.SelectType;
-import net.codjo.database.common.api.structure.SqlObject;
-import net.codjo.database.common.api.structure.SqlTable;
-import static net.codjo.database.common.api.structure.SqlTable.table;
-import net.codjo.database.common.impl.fixture.MapOrderListTransformer;
-import net.codjo.test.common.fixture.Fixture;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
@@ -14,7 +8,14 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import junit.framework.Assert;
+import net.codjo.database.common.api.DatabaseQueryHelper.SelectType;
+import net.codjo.database.common.api.structure.SqlObject;
+import net.codjo.database.common.api.structure.SqlTable;
+import net.codjo.database.common.impl.fixture.MapOrderListTransformer;
+import net.codjo.test.common.fixture.Fixture;
+
 import static junit.framework.Assert.assertEquals;
+import static net.codjo.database.common.api.structure.SqlTable.table;
 public abstract class JdbcFixture implements Fixture {
     private final DatabaseFactory databaseFactory = new DatabaseFactory();
     private final DatabaseHelper databaseHelper = databaseFactory.createDatabaseHelper();
@@ -180,15 +181,16 @@ public abstract class JdbcFixture implements Fixture {
                 Assert.assertNull("Expected empty but was not", actualValue);
                 return;
             }
-            int line = expectedValue.length;
             int columnCount = expectedValue[0].length;
 
-            for (int lineIndex = 0; lineIndex < line; lineIndex++) {
+            for (int rowIndex = 0; rowIndex < expectedValue.length; rowIndex++) {
                 for (int columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-                    assertEquals(expectedValue[lineIndex][columnIndex],
-                                 actualValue[lineIndex][columnIndex]);
+                    assertEquals(expectedValue[rowIndex][columnIndex], actualValue[rowIndex][columnIndex]);
                 }
+                Assert.assertEquals("On row[" + (rowIndex + 1) + "] column count",
+                                    expectedValue[rowIndex].length, actualValue[rowIndex].length);
             }
+            Assert.assertEquals("Total row count", expectedValue.length, actualValue.length);
         }
         catch (SQLException e) {
             throw new RuntimeSqlException(e);
@@ -288,6 +290,7 @@ public abstract class JdbcFixture implements Fixture {
         if (resultContent.isEmpty()) {
             return null;
         }
+        //noinspection ToArrayCallWithZeroLengthArrayArgument
         return resultContent.toArray(new String[][]{});
     }
 }

--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/structure/SqlConstraint.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/structure/SqlConstraint.java
@@ -7,6 +7,13 @@ public class SqlConstraint extends AbstractSqlObject {
     private SqlTable alteredTable;
     private SqlTable referencedTable;
     private final List<SqlField[]> linkedFields = new ArrayList<SqlField[]>();
+    private Type type = Type.PRIMARY;
+
+    public enum Type {
+        UNIQUE,
+        FOREIGN,
+        PRIMARY
+    }
 
 
     protected SqlConstraint() {
@@ -71,7 +78,9 @@ public class SqlConstraint extends AbstractSqlObject {
 
 
     public static SqlConstraint foreignKey(String name, SqlTable alteredTable) {
-        return new SqlConstraint(name, alteredTable);
+        SqlConstraint sqlConstraint = new SqlConstraint(name, alteredTable);
+        sqlConstraint.setType(Type.FOREIGN);
+        return sqlConstraint;
     }
 
 
@@ -87,6 +96,17 @@ public class SqlConstraint extends AbstractSqlObject {
             constraint.addLinkedFields(alteredFields[i], referencedFields[i]);
         }
         constraint.setReferencedTable(referencedTable);
+        constraint.setType(Type.FOREIGN);
         return constraint;
+    }
+
+
+    public Type getType() {
+        return type;
+    }
+
+
+    public void setType(Type type) {
+        this.type = type;
     }
 }

--- a/codjo-database-common/src/main/java/net/codjo/database/common/impl/query/builder/AbstractInsertQueryBuilder.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/impl/query/builder/AbstractInsertQueryBuilder.java
@@ -1,9 +1,9 @@
 package net.codjo.database.common.impl.query.builder;
-import net.codjo.database.common.api.structure.SqlField;
-import net.codjo.database.common.api.structure.SqlTable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import net.codjo.database.common.api.structure.SqlField;
+import net.codjo.database.common.api.structure.SqlTable;
 public abstract class AbstractInsertQueryBuilder extends AbstractQueryBuilder {
     protected SqlTable table;
     protected final List<SqlField> fields = new ArrayList<SqlField>();
@@ -26,10 +26,10 @@ public abstract class AbstractInsertQueryBuilder extends AbstractQueryBuilder {
         StringBuilder insert = new StringBuilder()
               .append("insert into ").append(getTableName()).append(" ");
         SqlField firstField = fields.get(0);
-        if (firstField.getName() != null) {
+        if (formatFieldName(firstField) != null) {
             insert.append("( ");
             for (SqlField field : fields) {
-                insert.append(field.getName()).append(", ");
+                insert.append(formatFieldName(field)).append(", ");
             }
             insert.delete(insert.length() - 2, insert.length());
             insert.append(" ) ");

--- a/codjo-database-common/src/main/java/net/codjo/database/common/impl/query/builder/AbstractQueryBuilder.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/impl/query/builder/AbstractQueryBuilder.java
@@ -12,4 +12,9 @@ public abstract class AbstractQueryBuilder {
         }
         return value.toString();
     }
+
+
+    protected String formatFieldName(SqlField sqlField) {
+        return sqlField.getName();
+    }
 }

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoder.java
@@ -5,7 +5,7 @@ public class OracleDatabaseTranscoder extends DefaultDatabaseTranscoder {
     public OracleDatabaseTranscoder() {
         addSqlFieldType(LONGVARCHAR, "clob");
         addSqlFieldType(DATETIME, "timestamp");
-        addSqlFieldType("text", "varchar2(4000)");
+        addSqlFieldType("text", "clob");
         addSqlFieldType("bit", "number(1)");
         addSqlFieldType("varchar", "varchar2");
 

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoder.java
@@ -7,7 +7,7 @@ public class OracleDatabaseTranscoder extends DefaultDatabaseTranscoder {
         addSqlFieldType(DATETIME, "timestamp");
         addSqlFieldType("text", "varchar2(4000)");
         addSqlFieldType("bit", "number(1)");
-//        addSqlFieldType("varchar", "varchar2");
+        addSqlFieldType("varchar", "varchar2");
 
         addSqlFieldDefault(NOW, "systimestamp");
     }

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelper.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelper.java
@@ -109,9 +109,6 @@ public class OracleDatabaseScriptHelper extends AbstractDatabaseScriptHelper {
     @Override
     public String buildCreateConstraintScript(SqlConstraint constraint) {
         return new StringBuilder()
-              .append(buildCreatePrimaryKeyQuery(constraint.getReferencedTable(),
-                                                 constraint.getLinkedFields())).append(";\n")
-              .append("\n")
               .append(getQueryHelper().buildCreateConstraintQuery(constraint)).append(";\n")
               .toString();
     }

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/OracleDatabaseQueryHelper.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/OracleDatabaseQueryHelper.java
@@ -1,4 +1,6 @@
 package net.codjo.database.oracle.impl.query;
+import java.sql.Connection;
+import java.sql.SQLException;
 import net.codjo.database.common.impl.query.AbstractDatabaseQueryHelper;
 import net.codjo.database.common.impl.query.builder.AbstractAlterTableQueryBuilder;
 import net.codjo.database.common.impl.query.builder.AbstractCreateConstraintQueryBuilder;
@@ -10,8 +12,6 @@ import net.codjo.database.common.impl.query.builder.AbstractDropTableQueryBuilde
 import net.codjo.database.common.impl.query.builder.AbstractInsertQueryBuilder;
 import net.codjo.database.common.impl.query.builder.AbstractSelectQueryBuilder;
 import net.codjo.database.common.impl.query.builder.AbstractUpdateQueryBuilder;
-import net.codjo.database.common.impl.query.builder.DefaultCreateConstraintQueryBuilder;
-import net.codjo.database.common.impl.query.builder.DefaultCreateIndexQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultCreateViewQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultDropConstraintQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultDropTableQueryBuilder;
@@ -20,9 +20,9 @@ import net.codjo.database.common.impl.query.builder.DefaultSelectQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultUpdateQueryBuilder;
 import net.codjo.database.common.impl.query.runner.DefaultRowCountStrategy;
 import net.codjo.database.common.impl.query.runner.RowCountStrategy;
+import net.codjo.database.oracle.impl.query.builder.OracleCreateConstraintQueryBuilder;
+import net.codjo.database.oracle.impl.query.builder.OracleCreateIndexQueryBuilder;
 import net.codjo.database.oracle.impl.query.builder.OracleCreateTableQueryBuilder;
-import java.sql.Connection;
-import java.sql.SQLException;
 public class OracleDatabaseQueryHelper extends AbstractDatabaseQueryHelper {
 
     @Override
@@ -69,7 +69,7 @@ public class OracleDatabaseQueryHelper extends AbstractDatabaseQueryHelper {
 
     @Override
     protected AbstractCreateIndexQueryBuilder newCreateIndexQueryBuilder() {
-        return new DefaultCreateIndexQueryBuilder();
+        return new OracleCreateIndexQueryBuilder();
     }
 
 
@@ -81,7 +81,7 @@ public class OracleDatabaseQueryHelper extends AbstractDatabaseQueryHelper {
 
     @Override
     protected AbstractCreateConstraintQueryBuilder newCreateConstraintQueryBuilder() {
-        return new DefaultCreateConstraintQueryBuilder();
+        return new OracleCreateConstraintQueryBuilder();
     }
 
 

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/OracleDatabaseQueryHelper.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/OracleDatabaseQueryHelper.java
@@ -15,7 +15,6 @@ import net.codjo.database.common.impl.query.builder.AbstractUpdateQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultCreateViewQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultDropConstraintQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultDropTableQueryBuilder;
-import net.codjo.database.common.impl.query.builder.DefaultInsertQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultSelectQueryBuilder;
 import net.codjo.database.common.impl.query.builder.DefaultUpdateQueryBuilder;
 import net.codjo.database.common.impl.query.runner.DefaultRowCountStrategy;
@@ -23,6 +22,7 @@ import net.codjo.database.common.impl.query.runner.RowCountStrategy;
 import net.codjo.database.oracle.impl.query.builder.OracleCreateConstraintQueryBuilder;
 import net.codjo.database.oracle.impl.query.builder.OracleCreateIndexQueryBuilder;
 import net.codjo.database.oracle.impl.query.builder.OracleCreateTableQueryBuilder;
+import net.codjo.database.oracle.impl.query.builder.OracleInsertQueryBuilder;
 public class OracleDatabaseQueryHelper extends AbstractDatabaseQueryHelper {
 
     @Override
@@ -51,7 +51,7 @@ public class OracleDatabaseQueryHelper extends AbstractDatabaseQueryHelper {
 
     @Override
     protected AbstractInsertQueryBuilder newInsertQueryBuilder() {
-        return new DefaultInsertQueryBuilder();
+        return new OracleInsertQueryBuilder();
     }
 
 

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateConstraintQueryBuilder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateConstraintQueryBuilder.java
@@ -1,0 +1,41 @@
+package net.codjo.database.oracle.impl.query.builder;
+import net.codjo.database.common.api.structure.SqlConstraint.Type;
+import net.codjo.database.common.api.structure.SqlField;
+import net.codjo.database.common.impl.query.builder.AbstractCreateConstraintQueryBuilder;
+/**
+ *
+ */
+public class OracleCreateConstraintQueryBuilder extends AbstractCreateConstraintQueryBuilder {
+    @Override
+    public String get() {
+        StringBuilder alter = new StringBuilder()
+              .append("alter table ").append(constraint.getAlteredTable().getName())
+              .append(" add constraint ").append(constraint.getName());
+        switch (constraint.getType()) {
+            case UNIQUE:
+                alter.append(" unique (");
+                break;
+            case PRIMARY:
+                alter.append(" primary key (");
+                break;
+            case FOREIGN:
+                alter.append(" foreign key (");
+                break;
+        }
+        for (SqlField[] linkedFields : constraint.getLinkedFields()) {
+            alter.append(linkedFields[0].getName()).append(", ");
+        }
+        alter.delete(alter.length() - 2, alter.length());
+
+        if (constraint.getType().equals(Type.FOREIGN)) {
+            alter.append(") references ")
+                  .append(constraint.getReferencedTable().getName()).append(" (");
+            for (SqlField[] linkedFields : constraint.getLinkedFields()) {
+                alter.append(linkedFields[1].getName()).append(", ");
+            }
+            alter.delete(alter.length() - 2, alter.length());
+        }
+        return alter.append(")").toString();
+    }
+}
+

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateIndexQueryBuilder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateIndexQueryBuilder.java
@@ -1,0 +1,44 @@
+package net.codjo.database.oracle.impl.query.builder;
+import net.codjo.database.common.api.structure.SqlField;
+import net.codjo.database.common.api.structure.SqlIndex;
+import net.codjo.database.common.impl.query.builder.AbstractCreateIndexQueryBuilder;
+/**
+ *
+ */
+public class OracleCreateIndexQueryBuilder extends AbstractCreateIndexQueryBuilder {
+
+    @Override
+    public String get() {
+        StringBuilder create = new StringBuilder("create ");
+        switch (index.getType()) {
+            case UNIQUE:
+            case PRIMARY_KEY:
+            case UNIQUE_CLUSTERED:
+            case PRIMARY_KEY_CLUSTERED:
+                return alterTableAddUniqueConstraint(index);
+            case NORMAL:
+            case CLUSTERED:
+                break;
+        }
+        create.append("index ").append(index.getName())
+              .append(" on ").append(index.getTable().getName()).append(" (");
+        for (SqlField field : index.getFields()) {
+            create.append(field.getName()).append(", ");
+        }
+        create.delete(create.length() - 2, create.length());
+        return create.append(")").toString();
+    }
+
+
+    private String alterTableAddUniqueConstraint(SqlIndex index) {
+        StringBuilder sqlString;
+        sqlString = new StringBuilder("alter table ").append(this.index.getTable().getName())
+              .append(" add (constraint ").append(this.index.getName()).append(" unique (");
+        for (SqlField field : index.getFields()) {
+            sqlString.append(field.getName()).append(", ");
+        }
+        sqlString.delete(sqlString.length() - 2, sqlString.length());
+        return sqlString.append("))").toString();
+    }
+}
+

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleInsertQueryBuilder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleInsertQueryBuilder.java
@@ -1,0 +1,28 @@
+package net.codjo.database.oracle.impl.query.builder;
+import net.codjo.database.common.api.structure.SqlField;
+import net.codjo.database.common.impl.query.builder.AbstractInsertQueryBuilder;
+/**
+ *
+ */
+public class OracleInsertQueryBuilder extends AbstractInsertQueryBuilder {
+
+    protected final String getTableName() {
+        return table.getName();
+    }
+
+
+    @Override
+    protected String formatFieldName(SqlField sqlField) {
+        String name = sqlField.getName();
+        if (isOracleKeyword(name)) {
+            return "\"" + name + "\"";
+        }
+        return name;
+    }
+
+
+    //TODO[]Oracle support] commonaliser avec OracleDatabaseScriptHelper
+    private boolean isOracleKeyword(String name) {
+        return "COMMENT".equals(name);
+    }
+}

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoderTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/OracleDatabaseTranscoderTest.java
@@ -1,6 +1,7 @@
 package net.codjo.database.oracle.impl;
-import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 public class OracleDatabaseTranscoderTest {
 
     @Test
@@ -10,7 +11,7 @@ public class OracleDatabaseTranscoderTest {
         assertEquals("timestamp", transcoder.transcodeSqlFieldType("datetime"));
         assertEquals("integer", transcoder.transcodeSqlFieldType("integer"));
         assertEquals("clob", transcoder.transcodeSqlFieldType("longvarchar"));
-        assertEquals("varchar", transcoder.transcodeSqlFieldType("varchar"));
+        assertEquals("varchar2", transcoder.transcodeSqlFieldType("varchar"));
 
         assertEquals("systimestamp", transcoder.transcodeSqlFieldDefault("now"));
     }

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelperTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelperTest.java
@@ -36,7 +36,7 @@ public class OracleDatabaseScriptHelperTest extends AbstractDatabaseScriptHelper
         String definition = scriptHelper.buildCreateTableScript(table);
 
         assertThat(cleanUp(definition), is("create table AP_TABLE("
-                                           + "    \"COMMENT\"      varchar(15)  null"
+                                           + "    \"COMMENT\"      varchar2(15)  null"
                                            + " constraint CKC_COMMENT check (\"COMMENT\" in ('A','B'))"
                                            + ");"));
     }
@@ -63,8 +63,8 @@ public class OracleDatabaseScriptHelperTest extends AbstractDatabaseScriptHelper
 
     @Override
     protected SqlConstraint buildConstraint() {
-        create(table("AP_TOTO"), "PORTFOLIO_CODE varchar(6), AUTOMATIC_UPDATE varchar(6)");
-        create(table("AP_MERETOTO"), "ISIN_CODE varchar(6), AUTOMATIC_UPDATE varchar(6)");
+        create(table("AP_TOTO"), "PORTFOLIO_CODE varchar2(6), AUTOMATIC_UPDATE varchar2(6)");
+        create(table("AP_MERETOTO"), "ISIN_CODE varchar2(6), AUTOMATIC_UPDATE varchar2(6)");
 
         create(buildUniqueConstraint(table("AP_MERETOTO")));
 

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelperTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseScriptHelperTest.java
@@ -25,6 +25,25 @@ public class OracleDatabaseScriptHelperTest extends AbstractDatabaseScriptHelper
 
 
     @Test
+    public void test_createTable_withSequence() throws Exception {
+        //TODO[Oracle support] test a finir
+        SqlTableDefinition table = new SqlTableDefinition("AP_TABLE");
+        SqlFieldDefinition comment = new SqlFieldDefinition("COMMENT");
+        comment.setType("varchar");
+        comment.setPrecision("15");
+        comment.setCheck("'A','B'");
+        table.setSqlFieldDefinitions(Arrays.asList(comment));
+
+        String definition = scriptHelper.buildCreateTableScript(table);
+
+        assertThat(cleanUp(definition), is("create table AP_TABLE("
+                                           + "    \"COMMENT\"      varchar2(15)  null"
+                                           + " constraint CKC_COMMENT check (\"COMMENT\" in ('A','B'))"
+                                           + ");"));
+    }
+
+
+    @Test
     public void test_createTable_withReservedKeyword() throws Exception {
         SqlTableDefinition table = new SqlTableDefinition("AP_TABLE");
         SqlFieldDefinition comment = new SqlFieldDefinition("COMMENT");

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/constraint/createConstraint_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/constraint/createConstraint_etalon.sql
@@ -1,3 +1,1 @@
-alter table AP_MERETOTO add (constraint pk_AP_MERETOTO primary key (ISIN_CODE, AUTOMATIC_UPDATE));
-
 alter table AP_TOTO add constraint FK_MERETOTO_TOTO foreign key (PORTFOLIO_CODE, AUTOMATIC_UPDATE) references AP_MERETOTO (ISIN_CODE, AUTOMATIC_UPDATE);

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/index/createUniqueIndex_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/index/createUniqueIndex_etalon.sql
@@ -1,1 +1,1 @@
-create unique index X1_AP_TOTO on AP_TOTO (PORTFOLIO_CODE, AUTOMATIC_UPDATE);
+alter table AP_TOTO add (constraint X1_AP_TOTO unique (PORTFOLIO_CODE, AUTOMATIC_UPDATE));

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/table/createTable_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/table/createTable_etalon.sql
@@ -1,7 +1,7 @@
 create table AP_GROUP_PERSON
 (
     MY_ID      integer  not null,
-    MY_VARCHAR      varchar(15)  null
+    MY_VARCHAR      varchar2(15)  null
  constraint CKC_MY_VARCHAR check (MY_VARCHAR in ('A','B')),
     MY_TIMESTAMP      timestamp default systimestamp  null
 );

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createCheckRecordTrigger_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createCheckRecordTrigger_etalon.sql
@@ -1,9 +1,10 @@
 create or replace trigger TR_AP_TOTO_IU
     after insert or update on AP_TOTO for each row
-
 declare
-    parentCount number := 0;
+    v_errno    NUMBER(12);
+    v_errmsg   VARCHAR2(255);
 
+    parentCount number := 0;
 begin
 
     select count(1) into parentCount
@@ -15,7 +16,12 @@ begin
            'Parent does not exist in "AP_PARENT_TOTO". Cannot create child in "AP_TOTO".');
   end if;
 
-end TR_AP_TOTO_IU;
+return;
+   /*  Errors handling  */
+   <<error>>
+   raise_application_error( -20002, v_errno|| ':' ||v_errmsg );
+   ROLLBACK;
+end;
 /
 
 prompt Trigger TR_AP_TOTO_IU created

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createDeleteCascadeTrigger_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createDeleteCascadeTrigger_etalon.sql
@@ -1,5 +1,9 @@
 create or replace trigger TR_AP_TOTO_D
     after delete on AP_TOTO for each row
+declare
+    v_errno    NUMBER(12);
+    v_errmsg   VARCHAR2(255);
+
 begin
 
     /*  Delete all children in "AP_CHILD1_TOTO"  */
@@ -15,7 +19,12 @@ begin
 
 // CUSTOM SQL CODE
 
-end TR_AP_TOTO_D;
+return;
+   /*  Errors handling  */
+   <<error>>
+   raise_application_error( -20002, v_errno|| ':' ||v_errmsg );
+   ROLLBACK;
+end;
 /
 
 prompt Trigger TR_AP_TOTO_D created

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createDeleteTrigger_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createDeleteTrigger_etalon.sql
@@ -1,10 +1,19 @@
 create or replace trigger TR_AP_TOTO_D
     after delete on AP_TOTO for each row
+declare
+    v_errno    NUMBER(12);
+    v_errmsg   VARCHAR2(255);
+
 begin
 
 // CUSTOM SQL CODE
 
-end TR_AP_TOTO_D;
+return;
+   /*  Errors handling  */
+   <<error>>
+   raise_application_error( -20002, v_errno|| ':' ||v_errmsg );
+   ROLLBACK;
+end;
 /
 
 prompt Trigger TR_AP_TOTO_D created

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createInsertTrigger_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createInsertTrigger_etalon.sql
@@ -1,10 +1,19 @@
 create or replace trigger TR_AP_TOTO_I
     after insert on AP_TOTO for each row
+declare
+    v_errno    NUMBER(12);
+    v_errmsg   VARCHAR2(255);
+
 begin
 
 // CUSTOM SQL CODE
 
-end TR_AP_TOTO_I;
+return;
+   /*  Errors handling  */
+   <<error>>
+   raise_application_error( -20002, v_errno|| ':' ||v_errmsg );
+   ROLLBACK;
+end;
 /
 
 prompt Trigger TR_AP_TOTO_I created

--- a/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createUpdateTrigger_etalon.sql
+++ b/codjo-database-oracle/src/test/resources/net/codjo/database/oracle/impl/helper/trigger/createUpdateTrigger_etalon.sql
@@ -1,10 +1,19 @@
 create or replace trigger TR_AP_TOTO_U
     after update on AP_TOTO for each row
+declare
+    v_errno    NUMBER(12);
+    v_errmsg   VARCHAR2(255);
+
 begin
 
 // CUSTOM SQL CODE
 
-end TR_AP_TOTO_U;
+return;
+   /*  Errors handling  */
+   <<error>>
+   raise_application_error( -20002, v_errno|| ':' ||v_errmsg );
+   ROLLBACK;
+end;
 /
 
 prompt Trigger TR_AP_TOTO_U created


### PR DESCRIPTION
## Fix bug in the table assert content method of the JdbcFixture
### Context

During a unit test, we discovered that the `JdbcFixture.assertContent()` was not failing when the actual table had more rows than expected. 
### Description

The bug has been nicely fixed.
## Oracle Support Improvements
### Context

Oracle Support Improvement project.
### Description

The following aspects have been improved
- Foreign keys management
- Unique Constraints generation 
- Use more Oracle specific type (varchar2 instead of varchar)
- Improve Clob support
- Handle use of reserved word in select queries (e.g. "COMMENT")
