### PR TITLE
Replace truncate table by delete of the table for Oracle

### DIFF
--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelper.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelper.java
@@ -46,22 +46,13 @@ public class OracleDatabaseHelper extends AbstractDatabaseHelper {
             return;
         }
 
-        List<String> constraints = getUniqueConstraints(connection, table.getName());
-        Map<String, String> foreignKeys = getLinkedForeignKeys(connection, constraints);
-
-        enabledForeignKeys(connection, foreignKeys, false);
-        enabledUniqueConstraints(connection, table.getName(), constraints, false);
-
         Statement statement = connection.createStatement();
         try {
-            statement.executeUpdate("truncate table " + table.getName());
+            statement.executeUpdate("delete from " + table.getName());
         }
         finally {
             statement.close();
         }
-
-        enabledUniqueConstraints(connection, table.getName(), constraints, true);
-        enabledForeignKeys(connection, foreignKeys, true);
     }
 
 

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateTableQueryBuilder.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/query/builder/OracleCreateTableQueryBuilder.java
@@ -12,7 +12,7 @@ public class OracleCreateTableQueryBuilder extends AbstractCreateTableQueryBuild
         create.append("table ").append(table.getName())
               .append(" ( ").append(content).append(" )");
         if (table.isTemporary()) {
-            create.append(" on commit preserve rows");
+            create.append(" on commit delete rows");
         }
         return create.toString();
     }

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelperTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelperTest.java
@@ -1,5 +1,6 @@
 package net.codjo.database.oracle.impl.helper;
 import java.io.IOException;
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Properties;
@@ -42,7 +43,7 @@ public class OracleDatabaseHelperTest extends AbstractDatabaseHelperTest {
     public void test_dropForeignKey() throws Exception {
         jdbcFixture.drop(table("JDBC_TEST_1"));
         jdbcFixture.drop(table("JDBC_FIXTURE_TEST"));
-        
+
         jdbcFixture.create(table("JDBC_TEST_1"), "COL_A varchar(5)");
         jdbcFixture.create(table("JDBC_FIXTURE_TEST"), "COL_A varchar(5) constraint UN_COL_A unique");
         jdbcFixture.executeUpdate("alter table JDBC_TEST_1 add constraint FK_1 foreign key (COL_A) "
@@ -83,7 +84,8 @@ public class OracleDatabaseHelperTest extends AbstractDatabaseHelperTest {
               "alter table AP_BOOK add constraint FK_AUTH_BOOK foreign key (AUTHOR) references REF_AUTHOR (AUTHOR)");
 
         // Grant
-        jdbcFixture.executeUpdate("grant select, insert, delete, update, references on AP_BOOK                         to APP_USER");
+        jdbcFixture.executeUpdate(
+              "grant select, insert, delete, update, references on AP_BOOK                         to APP_USER");
 
         // Drop FK
         databaseHelper.dropAllObjects(jdbcFixture.getConnection());
@@ -239,6 +241,20 @@ public class OracleDatabaseHelperTest extends AbstractDatabaseHelperTest {
         }
         catch (SQLException exception) {
             ;
+        }
+    }
+
+
+    @Override
+    public void test_truncateTable_temporaryTable() throws Exception {
+        Connection connection = super.jdbcFixture.getConnection();
+        connection.setAutoCommit(false);
+        try {
+            super.test_truncateTable_temporaryTable();
+        }
+        finally {
+            connection.commit();
+            connection.setAutoCommit(true);
         }
     }
 }

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/query/builder/OracleCreateTableQueryBuilderTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/query/builder/OracleCreateTableQueryBuilderTest.java
@@ -12,7 +12,7 @@ public class OracleCreateTableQueryBuilderTest extends AbstractCreateTableQueryB
 
     @Override
     protected String getCreateTemporaryTableQuery() {
-        return "create global temporary table MA_TABLE ( COL1 varchar(255) ) on commit preserve rows";
+        return "create global temporary table MA_TABLE ( COL1 varchar(255) ) on commit delete rows";
     }
 
 


### PR DESCRIPTION
### Context

The data insertion during TR for Oracle takes a long time.
### Description

It was the suppression of the preceding data that was taking a long time.
A table truncate is longer that a delete, so the truncates are replaced by deletes.
