### PR TITLE
Hsqldb Implementation - normalisation

### DIFF
--- a/codjo-database-common/src/main/java/net/codjo/database/common/impl/script/AbstractExecSqlScript.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/impl/script/AbstractExecSqlScript.java
@@ -7,7 +7,8 @@ import java.util.List;
 import net.codjo.database.common.api.ConnectionMetadata;
 import net.codjo.database.common.api.ExecSqlScript;
 import net.codjo.util.file.FileUtil;
-import static net.codjo.test.common.PathUtil.normalize;
+
+import static net.codjo.util.file.PathUtil.normalize;
 
 public abstract class AbstractExecSqlScript implements ExecSqlScript {
     private static final String NEW_LINE = System.getProperty("line.separator");

--- a/codjo-database-hsqldb/pom.xml
+++ b/codjo-database-hsqldb/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
-			<classifier>jdk5</classifier>
+            <classifier>${envClassifier}</classifier>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Description
1. `normalize` method has been moved from `codjo-test-common` `PathUtil` class to a new `PathUtil` class in `codjo-util` (production code versus test code).
2. Hsqldb dependency has been upgraded to 2.2.8 see:   https://github.com/codjo/codjo-pom/pull/40
