### PR TITLE
Centralisation of connection's construction and customisation

### DIFF
--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/ConnectionMetadata.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/ConnectionMetadata.java
@@ -31,6 +31,14 @@ public class ConnectionMetadata {
         if (user == null) {
             loadFromJdbc(databaseProperties);
         }
+        if (user == null) {
+            loadFromServerConfig(databaseProperties);
+        }
+    }
+
+
+    private void loadFromServerConfig(Properties databaseProperties) {
+        loadFromProperties(databaseProperties, "");
     }
 
 
@@ -125,7 +133,12 @@ public class ConnectionMetadata {
 
 
     private void loadFromProperties(Properties databaseProperties, String prefix) {
-        String server = databaseProperties.getProperty(prefix + ".server");
+        String smartPrefix = prefix;
+        if (prefix.length() != 0) {
+            smartPrefix += ".";
+        }
+
+        String server = databaseProperties.getProperty(smartPrefix + "server");
         if (server != null) {
             String[] tokens = server.split(":");
             if (tokens.length >= 2) {
@@ -137,11 +150,11 @@ public class ConnectionMetadata {
                 port = null;
             }
         }
-        user = databaseProperties.getProperty(prefix + ".user");
-        password = databaseProperties.getProperty(prefix + ".pwd");
-        catalog = databaseProperties.getProperty(prefix + ".catalog");
-        base = databaseProperties.getProperty(prefix + ".base");
-        charset = databaseProperties.getProperty(prefix + ".charset");
+        user = databaseProperties.getProperty(smartPrefix + "user");
+        password = databaseProperties.getProperty(smartPrefix + "pwd");
+        catalog = databaseProperties.getProperty(smartPrefix + "catalog");
+        base = databaseProperties.getProperty(smartPrefix + "base");
+        charset = databaseProperties.getProperty(smartPrefix + "charset");
         schema = null;
     }
 }

--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/DatabaseHelper.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/DatabaseHelper.java
@@ -1,11 +1,19 @@
 package net.codjo.database.common.api;
-import net.codjo.database.common.api.structure.SqlConstraint;
-import net.codjo.database.common.api.structure.SqlTable;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
+import net.codjo.database.common.api.structure.SqlConstraint;
+import net.codjo.database.common.api.structure.SqlTable;
 public interface DatabaseHelper {
+
+    final String LANGUAGE_KEY = "LANGUAGE";
+    final String CATALOG_KEY = "CATALOG";
+    final String CHARSET_KEY = "CHARSET";
+    final String USER_KEY = "user";
+    final String PASSWORD_KEY = "password";
+
 
     String getDriverClassName();
 
@@ -17,6 +25,9 @@ public interface DatabaseHelper {
 
 
     ConnectionMetadata createLibraryConnectionMetadata();
+
+
+    Connection createConnection(String url, Properties properties) throws SQLException;
 
 
     Connection createConnection(ConnectionMetadata connectionMetadata) throws SQLException;

--- a/codjo-database-common/src/test/java/net/codjo/database/common/api/ConnectionMetadataTest.java
+++ b/codjo-database-common/src/test/java/net/codjo/database/common/api/ConnectionMetadataTest.java
@@ -1,0 +1,55 @@
+package net.codjo.database.common.api;
+import java.util.Properties;
+import junit.framework.TestCase;
+import org.junit.Test;
+/**
+ *
+ */
+public class ConnectionMetadataTest extends TestCase {
+
+    @Test
+    public void test_createConnexion_prefixDatabase() throws Exception {
+        Properties databaseProperties = buildProperties("database.");
+        ConnectionMetadata metadata= new ConnectionMetadata(databaseProperties);
+        assertNotNull(metadata.getUser());
+        assertNotNull(metadata.getHostname());
+    }
+
+    @Test
+    public void test_createConnexion_prefixJdbc() throws Exception {
+        Properties databaseProperties = buildProperties("jdbc.");
+        ConnectionMetadata metadata= new ConnectionMetadata(databaseProperties);
+        assertNotNull(metadata.getUser());
+        assertNotNull(metadata.getHostname());
+    }
+
+    @Test
+    public void test_createConnexion_prefixTokio() throws Exception {
+        Properties databaseProperties = buildProperties("tokio.jdbc.");
+        ConnectionMetadata metadata= new ConnectionMetadata(databaseProperties);
+        assertNotNull(metadata.getUser());
+        assertNotNull(metadata.getHostname());
+    }
+
+    @Test
+    public void test_createConnexion_NoPrefix() throws Exception {
+        Properties databaseProperties = buildProperties("");
+        ConnectionMetadata metadata= new ConnectionMetadata(databaseProperties);
+        assertNotNull(metadata.getUser());
+        assertNotNull(metadata.getHostname());
+    }
+
+
+    private Properties buildProperties(String prefix) {
+        Properties databaseProperties = new Properties();
+        databaseProperties.put(prefix+"user","LIB");
+        databaseProperties.put(prefix+"password","LIB");
+        databaseProperties.put(prefix+"base","LIB");
+        databaseProperties.put(prefix+"catalog","LIB");
+        databaseProperties.put(prefix+"schema","LIB");
+        databaseProperties.put(prefix+"charset","LIB");
+        databaseProperties.put(prefix+"hostname","GALABERT");
+        databaseProperties.put(prefix+"server","uncafesilvousplait:89/ca/ne/sera/pas/pris");
+        return databaseProperties;
+    }
+}

--- a/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelper.java
+++ b/codjo-database-oracle/src/main/java/net/codjo/database/oracle/impl/helper/OracleDatabaseHelper.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
 import net.codjo.database.common.api.ConnectionMetadata;
 import net.codjo.database.common.api.DatabaseQueryHelper;
 import net.codjo.database.common.api.structure.SqlTable;
@@ -52,6 +53,43 @@ public class OracleDatabaseHelper extends AbstractDatabaseHelper {
         }
         finally {
             statement.close();
+        }
+    }
+
+
+    @Override
+    protected void configureConnectionProperties(Properties connectionProperties) {
+        if (connectionProperties.getProperty(LANGUAGE_KEY) == null) {
+            connectionProperties.put(LANGUAGE_KEY, "french");
+        }
+        connectionProperties.put("oracle.jdbc.mapDateToTimestamp", "false");
+        connectionProperties.put("oracle.jdbc.J2EE13Compliant", "true");
+        String hostname = connectionProperties.getProperty("HOSTNAME");
+        if (hostname != null) {
+            connectionProperties.put("v$session.machine", hostname);
+        }
+    }
+
+
+    @Override
+    protected void configureSession(Connection connection, Properties connectionProperties) throws SQLException {
+        Statement statement = null;
+        try {
+            statement = connection.createStatement();
+            statement.execute("ALTER SESSION SET NLS_TIMESTAMP_FORMAT = 'YYYY-MM-DD HH24:MI:SS'");
+            statement.execute("ALTER SESSION SET NLS_DATE_FORMAT = 'YYYY-MM-DD'");
+            statement.execute("ALTER SESSION SET NLS_NUMERIC_CHARACTERS = '. '");
+
+            statement.execute("ALTER SESSION SET CURRENT_SCHEMA=" + connectionProperties.getProperty(CATALOG_KEY));
+            String language = connectionProperties.getProperty(LANGUAGE_KEY);
+            if (language != null) {
+                statement.execute("ALTER SESSION SET NLS_LANGUAGE= " + language);
+            }
+        }
+        finally {
+            if (statement != null) {
+                statement.close();
+            }
         }
     }
 

--- a/codjo-database-sybase/src/main/java/net/codjo/database/sybase/impl/helper/SybaseDatabaseHelper.java
+++ b/codjo-database-sybase/src/main/java/net/codjo/database/sybase/impl/helper/SybaseDatabaseHelper.java
@@ -118,7 +118,9 @@ public class SybaseDatabaseHelper extends AbstractDatabaseHelper {
 
     @Override
     protected void configureConnectionProperties(Properties connectionProperties) {
-        connectionProperties.put("LANGUAGE", "french");
+        if (connectionProperties.getProperty(LANGUAGE_KEY) == null) {
+            connectionProperties.put(LANGUAGE_KEY, "french");
+        }
     }
 
 


### PR DESCRIPTION
## Context

Oracle support : there were differences between unit tests database connections and production server connections.
## Description

Now, connection construction and customisation are centralised in `DatabaseHelper`. All the configuration is now in `codjo-database` and no more in `codjo-sql`.
