### PR TITLE
Add a TransactionManager

### DIFF
--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/TransactionManager.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/TransactionManager.java
@@ -1,0 +1,72 @@
+package net.codjo.database.common.api;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import org.apache.log4j.Logger;
+
+public abstract class TransactionManager<T> {
+    private boolean previousAutoCommitMode;
+    private boolean hasToChangeAutoCommit;
+    private final static Logger LOGGER = Logger.getLogger(TransactionManager.class);
+
+
+    public TransactionManager(Connection connection) throws SQLException {
+        previousAutoCommitMode = connection.getAutoCommit();
+        hasToChangeAutoCommit = hasToChangeAutoCommit();
+        if (hasToChangeAutoCommit) {
+            LOGGER.debug("[TransactionManager] changing autocommit mode to false");
+            connection.setAutoCommit(false);
+        }
+    }
+
+
+    boolean hasToChangeAutoCommit() {
+        return new DatabaseFactory().getDatabaseQueryHelper().hasDeleteRowStrategyOnTemporaryTable();
+    }
+
+
+    private void release(Connection connection) throws SQLException {
+        if (hasToChangeAutoCommit) {
+            LOGGER.debug("[TransactionManager] restoring autocommit to:" + previousAutoCommitMode);
+            if (connection != null) {
+                connection.setAutoCommit(previousAutoCommitMode);
+            }
+        }
+    }
+
+
+    private void commit(Connection connection) throws SQLException {
+        if (hasToChangeAutoCommit && !connection.getAutoCommit()) {
+            LOGGER.debug("[TransactionManager] Commiting transaction");
+            connection.commit();
+        }
+    }
+
+
+    private void rollback(Connection connection) throws SQLException {
+        if (hasToChangeAutoCommit && !connection.getAutoCommit()) {
+            LOGGER.debug("[TransactionManager] Rollbacking transaction");
+            connection.rollback();
+        }
+    }
+
+
+    //TODO[segolene] peut-etre renommer la methode ?
+    protected abstract T runSql(Connection connection) throws Exception;
+
+
+    public final T run(Connection connection) throws Exception {
+        try {
+            T result = runSql(connection);
+            commit(connection);
+            return result;
+        }
+        catch (Exception ex) {
+            rollback(connection);
+            throw ex;
+        }
+        finally {
+            release(connection);
+        }
+    }
+}

--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/TransactionManager.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/TransactionManager.java
@@ -10,7 +10,7 @@ public abstract class TransactionManager<T> {
     private final static Logger LOGGER = Logger.getLogger(TransactionManager.class);
 
 
-    public TransactionManager(Connection connection) throws SQLException {
+    protected TransactionManager(Connection connection) throws SQLException {
         previousAutoCommitMode = connection.getAutoCommit();
         hasToChangeAutoCommit = hasToChangeAutoCommit();
         if (hasToChangeAutoCommit) {
@@ -51,7 +51,6 @@ public abstract class TransactionManager<T> {
     }
 
 
-    //TODO[segolene] peut-etre renommer la methode ?
     protected abstract T runSql(Connection connection) throws Exception;
 
 

--- a/codjo-database-common/src/test/java/net/codjo/database/common/api/TransactionManagerTest.java
+++ b/codjo-database-common/src/test/java/net/codjo/database/common/api/TransactionManagerTest.java
@@ -68,8 +68,7 @@ public class TransactionManagerTest extends TestCase {
                                                           final String resultAsString, final CallBack callback)
           throws Exception {
         final Connection connection = new ConnectionMock(log).getStub();
-        TransactionManager<String> transactionManager
-              = new TransactionManager<String>(connection) {
+        TransactionManager<String> transactionManager = new TransactionManager<String>(connection) {
             @Override
             protected String runSql(Connection connection) throws SQLException {
                 log.call("runSql");
@@ -86,7 +85,6 @@ public class TransactionManagerTest extends TestCase {
     }
 
 
-    //TODO[segolene] peut-etre renommer l'interface ?
     private interface CallBack {
         String doIt(final String result) throws SQLException;
     }

--- a/codjo-database-common/src/test/java/net/codjo/database/common/api/TransactionManagerTest.java
+++ b/codjo-database-common/src/test/java/net/codjo/database/common/api/TransactionManagerTest.java
@@ -1,0 +1,93 @@
+package net.codjo.database.common.api;
+import java.sql.Connection;
+import java.sql.SQLException;
+import junit.framework.TestCase;
+import net.codjo.test.common.LogString;
+import net.codjo.test.common.mock.ConnectionMock;
+import org.junit.Test;
+/**
+ *
+ */
+public class TransactionManagerTest extends TestCase {
+    private LogString log = new LogString();
+
+
+    @Test
+    public void test_runSwitchAutocommit() throws Exception {
+        final String result = runTransactionManagerWithAutocommmitAt(true, "result");
+        log.assertContent(
+              "getAutoCommit(), setAutoCommit(false), runSql(), getAutoCommit(), commit(), setAutoCommit(false)");
+        assertEquals("result", result);
+    }
+
+
+    @Test
+    public void test_rundontSwitchAutocommit() throws Exception {
+        final String result = runTransactionManagerWithAutocommmitAt(false, "AnotherResult");
+        log.assertContent("getAutoCommit(), runSql()");
+        assertEquals("AnotherResult", result);
+    }
+
+
+    @Test
+    public void test_runWithException() throws Exception {
+        String result = null;
+        try {
+            result = runTransactionManagerWithException(true, "result");
+            fail();
+        }
+        catch (Exception e) {
+            log.assertContent(
+                  "getAutoCommit(), setAutoCommit(false), runSql(), getAutoCommit(), rollback(), setAutoCommit(false)");
+            assertNull(result);
+        }
+    }
+
+
+    private String runTransactionManagerWithAutocommmitAt(final boolean hasToChangeAutocommit,
+                                                          final String resultAsString) throws Exception {
+        return runTransactionManagerWithAutocommmitAt(hasToChangeAutocommit, resultAsString, new CallBack() {
+            public String doIt(final String result) {
+                return result;
+            }
+        });
+    }
+
+
+    private String runTransactionManagerWithException(final boolean hasToChangeAutocommit,
+                                                      final String resultAsString) throws Exception {
+        return runTransactionManagerWithAutocommmitAt(hasToChangeAutocommit, resultAsString, new CallBack() {
+            public String doIt(final String result) throws SQLException {
+                throw new SQLException("An exception has been thrown");
+            }
+        });
+    }
+
+
+    private String runTransactionManagerWithAutocommmitAt(final boolean hasToChangeAutocommit,
+                                                          final String resultAsString, final CallBack callback)
+          throws Exception {
+        final Connection connection = new ConnectionMock(log).getStub();
+        TransactionManager<String> transactionManager
+              = new TransactionManager<String>(connection) {
+            @Override
+            protected String runSql(Connection connection) throws SQLException {
+                log.call("runSql");
+                return callback.doIt(resultAsString);
+            }
+
+
+            @Override
+            boolean hasToChangeAutoCommit() {
+                return hasToChangeAutocommit;
+            }
+        };
+        return transactionManager.run(connection);
+    }
+
+
+    //TODO[segolene] peut-etre renommer l'interface ?
+    private interface CallBack {
+        String doIt(final String result) throws SQLException;
+    }
+}

--- a/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/fixture/OracleJdbcFixtureTest.java
+++ b/codjo-database-oracle/src/test/java/net/codjo/database/oracle/impl/fixture/OracleJdbcFixtureTest.java
@@ -113,19 +113,6 @@ public class OracleJdbcFixtureTest extends JdbcFixtureTest {
     }
 
 
-    // todo à supprimer dès que le script de création d'index oracle aura été implémenté
-    @Override
-    @Test
-    public void test_executeCreateTableScriptFile() throws Exception {
-        jdbcFixture.advanced()
-              .executeCreateTableScriptFile(new File(findResourcesFileDirectory(getClass()), "JdbcFixtureTest.tab"));
-
-        jdbcFixture.advanced().assertExists("JDBC_FIXTURE_TEST");
-
-        jdbcFixture.drop(table("JDBC_FIXTURE_TEST"));
-    }
-
-
     @Test
     public void test_spoolQuery() throws Exception {
         jdbcFixture.create(table("JDBC_FIXTURE_TEST"), "COL1 varchar(5), COL2 varchar(5)");


### PR DESCRIPTION
## Context

When working with Oracle temporary tables and `on commit delete rows` we often have to execute SQL code with a non autocommit connection.
## Description

`TransactionManager` class has been added to ease SQL code execution in a transaction.
## Example

``` java
TransactionManager<Void> transactionManager = new TransactionManager<Void>(connection) {

    @Override
    public Void runSql(Connection connection) throws Exception {
        tokioFixture.insertInputInDb(storyName);
        selector.proceed(context, connection, tempTableName, today);
        tokioFixture.assertAllOutputs(storyName);
        return null;
    }
};

transactionManager.run(connection);


```
