### PR TITLE
Bug fix truncate method on Mysql 5.5.30

### DIFF
--- a/codjo-database-mysql/src/test/java/net/codjo/database/mysql/impl/fixture/MysqlJdbcFixtureTest.java
+++ b/codjo-database-mysql/src/test/java/net/codjo/database/mysql/impl/fixture/MysqlJdbcFixtureTest.java
@@ -1,18 +1,19 @@
 package net.codjo.database.mysql.impl.fixture;
-import net.codjo.database.common.api.JdbcFixture;
-import static net.codjo.database.common.api.JdbcFixture.newFixture;
-import net.codjo.database.common.api.JdbcFixtureTest;
-import net.codjo.database.common.api.structure.SqlConstraint;
-import static net.codjo.database.common.api.structure.SqlConstraint.foreignKey;
-import static net.codjo.database.common.api.structure.SqlField.fields;
-import net.codjo.database.common.api.structure.SqlTable;
-import static net.codjo.database.common.api.structure.SqlTable.table;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.sql.SQLException;
-import static org.junit.Assert.assertEquals;
+import net.codjo.database.common.api.JdbcFixture;
+import net.codjo.database.common.api.JdbcFixtureTest;
+import net.codjo.database.common.api.structure.SqlConstraint;
+import net.codjo.database.common.api.structure.SqlTable;
 import org.junit.Before;
 import org.junit.Test;
+
+import static net.codjo.database.common.api.JdbcFixture.newFixture;
+import static net.codjo.database.common.api.structure.SqlConstraint.foreignKey;
+import static net.codjo.database.common.api.structure.SqlField.fields;
+import static net.codjo.database.common.api.structure.SqlTable.table;
+import static org.junit.Assert.assertEquals;
 public class MysqlJdbcFixtureTest extends JdbcFixtureTest {
 
     @Override

--- a/codjo-database-mysql/src/test/java/net/codjo/database/mysql/impl/helper/MysqlDatabaseHelperTest.java
+++ b/codjo-database-mysql/src/test/java/net/codjo/database/mysql/impl/helper/MysqlDatabaseHelperTest.java
@@ -1,19 +1,20 @@
 package net.codjo.database.mysql.impl.helper;
+import java.sql.SQLException;
+import java.util.Properties;
 import net.codjo.database.common.api.ConnectionMetadata;
 import net.codjo.database.common.api.DatabaseHelper;
 import net.codjo.database.common.api.ObjectType;
+import net.codjo.database.common.impl.helper.AbstractDatabaseHelperTest;
+import net.codjo.database.mysql.impl.query.MysqlDatabaseQueryHelper;
+import org.junit.Before;
+import org.junit.Test;
+
 import static net.codjo.database.common.api.structure.SqlConstraint.foreignKey;
 import static net.codjo.database.common.api.structure.SqlField.fieldName;
 import static net.codjo.database.common.api.structure.SqlIndex.normalIndex;
 import static net.codjo.database.common.api.structure.SqlTable.table;
-import net.codjo.database.common.impl.helper.AbstractDatabaseHelperTest;
-import net.codjo.database.mysql.impl.query.MysqlDatabaseQueryHelper;
-import java.sql.SQLException;
-import java.util.Properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import org.junit.Before;
-import org.junit.Test;
 public class MysqlDatabaseHelperTest extends AbstractDatabaseHelperTest {
 
     @Override
@@ -53,6 +54,26 @@ public class MysqlDatabaseHelperTest extends AbstractDatabaseHelperTest {
               .dropForeignKey(jdbcFixture.getConnection(), foreignKey("FK_1", table("JDBC_TEST_1")));
 
         jdbcFixture.advanced().assertDoesntExist(foreignKey("FK_1", table("JDBC_TEST_1")));
+    }
+
+
+    @Test
+    public void test_truncateWithForeignKey() throws Exception {
+        jdbcFixture.create(table("JDBC_TEST_1"), "COL_A varchar(5)");
+        jdbcFixture.create(table("JDBC_FIXTURE_TEST"), "COL_A varchar(5)");
+        jdbcFixture.executeUpdate("create unique index X1_JDBC_FIXTURE_TEST on JDBC_FIXTURE_TEST (COL_A)");
+        jdbcFixture.executeUpdate("alter table JDBC_TEST_1 add constraint FK_1 foreign key (COL_A) "
+                                  + "references JDBC_FIXTURE_TEST (COL_A)");
+
+        jdbcFixture.advanced().assertExists(foreignKey("FK_1", table("JDBC_TEST_1")));
+
+        final MysqlDatabaseHelper mysqlDatabaseHelper = (MysqlDatabaseHelper)databaseHelper;
+        int foreignKeyChecks_before = mysqlDatabaseHelper.getForeignKeyChecks(jdbcFixture.getConnection());
+
+        databaseHelper.truncateTable(jdbcFixture.getConnection(), table("JDBC_TEST_1"));
+
+        int foreignKeyChecks_after = mysqlDatabaseHelper.getForeignKeyChecks(jdbcFixture.getConnection());
+        assertEquals(foreignKeyChecks_before, foreignKeyChecks_after);
     }
 
 


### PR DESCRIPTION
## Context

Upgrade Mysql from 5.0.92 to 5.5.30.
## Description

In Mysql 5.5.30 foreign keys are checked before a truncate table and it fails if there is a foreign key on the table EVEN if there's no data.

Now, we disable foreign keys check before truncating a table by setting the `foreign_key_checks` session variable.
