### PR TITLE
New utility class to log jdbc errors and warnings

### DIFF
--- a/codjo-database-common/src/main/java/net/codjo/database/common/api/JdbcLogUtil.java
+++ b/codjo-database-common/src/main/java/net/codjo/database/common/api/JdbcLogUtil.java
@@ -1,0 +1,79 @@
+package net.codjo.database.common.api;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+/**
+ * Utility class for logging JDBC errors and warnings.
+ */
+public class JdbcLogUtil {
+    private JdbcLogUtil() {
+    }
+
+
+    /**
+     * Log the SQL state at {@link org.apache.log4j.Level.TRACE} level. The parameter <param>sqlException</param> gives the SQL state,
+     * which is compound of an optional error and optional warnings.
+     */
+    public static void traceWarningsAndError(Logger logger, SQLException sqlException) {
+        logWarningsAndError(logger, Level.TRACE, sqlException);
+    }
+
+
+    /**
+     * Log the SQL state at provided level. The parameter <param>sqlException</param> gives the SQL state, which is
+     * compound of an optional error and optional warnings.
+     */
+    public static void logWarningsAndError(Logger logger, Level level, SQLException sqlException) {
+        StringBuilder msg = new StringBuilder(128);
+        appendWarningsAndError(msg, sqlException);
+        logger.log(level, msg.toString());
+    }
+
+
+    /**
+     * Append the SQL state to the provided buffer. The parameter <param>sqlException</param> gives the SQL state, which
+     * is compound of an optional error and optional warnings.
+     */
+    public static void appendWarningsAndError(StringBuilder msg, SQLException sqlException) {
+        SQLException error = null;
+
+        if (sqlException != null) {
+            msg.append("\n----------- BEGIN trace SQL state -------------\n");
+            SQLException ex = sqlException;
+            while (ex != null) {
+                msg.append("- ");
+                if (ex instanceof SQLWarning) {
+                    msg.append("WARNING : ").append(ex.getMessage());
+                }
+                else {
+                    msg.append("ERROR : ").append(ex.getMessage());
+                    if (error != null) {
+                        msg.append("error already defined");
+                    }
+                    error = ex;
+                }
+                if (msg.charAt(msg.length() - 1) != '\n') {
+                    msg.append('\n');
+                }
+                appendNewLineIfNone(msg);
+                msg.append("\tSQLState: ").append(ex.getSQLState());
+                appendNewLineIfNone(msg);
+                msg.append("\tErrorCode: ").append(ex.getErrorCode()).append('\n');
+                ex = ex.getNextException();
+            }
+            msg.append("----------- END   trace SQL state -------------\n");
+        }
+        else {
+            msg.append("\nSQL state: no error or warnings\n");
+        }
+    }
+
+
+    private static void appendNewLineIfNone(StringBuilder msg) {
+        if (msg.charAt(msg.length() - 1) != '\n') {
+            msg.append('\n');
+        }
+    }
+}

--- a/codjo-database-common/src/test/java/net/codjo/database/common/api/JdbcLogUtilTest.java
+++ b/codjo-database-common/src/test/java/net/codjo/database/common/api/JdbcLogUtilTest.java
@@ -1,0 +1,102 @@
+package net.codjo.database.common.api;
+import java.sql.SQLException;
+import org.apache.log4j.Appender;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static net.codjo.test.common.matcher.JUnitMatchers.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+/**
+ * TODO[codjo-test] extract a Log4jFixture ?
+ */
+public class JdbcLogUtilTest {
+    private Appender appender;
+    private Logger logger;
+    private ArgumentCaptor<LoggingEvent> arguments;
+
+
+    @Before
+    public void doSetup() {
+        appender = mock(Appender.class);
+        logger = Logger.getRootLogger();
+        logger.addAppender(appender);
+        arguments = ArgumentCaptor.forClass(LoggingEvent.class);
+        logger.setLevel(Level.TRACE);
+    }
+
+
+    @After
+    public void doTearDown() {
+        logger.removeAppender(appender);
+    }
+
+
+    @Test
+    public void test_logWithLogLevel() throws Exception {
+        JdbcLogUtil.logWarningsAndError(logger, Level.INFO, new SQLException("La raison c'est que ca va pas trop",
+                                                                             "SQL_STATE_MOCK",
+                                                                             52000));
+
+        verifyLogger(Level.INFO, "\n----------- BEGIN trace SQL state -------------\n"
+                                 + "- ERROR : La raison c'est que ca va pas trop\n"
+                                 + "\tSQLState: SQL_STATE_MOCK\n"
+                                 + "\tErrorCode: 52000\n"
+                                 + "----------- END   trace SQL state -------------\n");
+    }
+
+
+    @Test
+    public void test_logWithNullException() throws Exception {
+        JdbcLogUtil.traceWarningsAndError(logger, null);
+        verifyLogger(Level.TRACE, "\nSQL state: no error or warnings\n");
+    }
+
+
+    @Test
+    public void test_logWithEmptySqlException() throws Exception {
+        JdbcLogUtil.traceWarningsAndError(logger, new SQLException());
+        verifyLogger(Level.TRACE, "\n----------- BEGIN trace SQL state -------------\n"
+                                  + "- ERROR : null\n"
+                                  + "\tSQLState: null\n"
+                                  + "\tErrorCode: 0\n"
+                                  + "----------- END   trace SQL state -------------\n");
+    }
+
+
+    @Test
+    public void test_logWithErrorCode() throws Exception {
+        JdbcLogUtil.traceWarningsAndError(logger, new SQLException("La raison c'est que ca va pas trop",
+                                                                   "SQL_STATE_MOCK",
+                                                                   52000));
+        verifyLogger(Level.TRACE, "\n----------- BEGIN trace SQL state -------------\n"
+                                  + "- ERROR : La raison c'est que ca va pas trop\n"
+                                  + "\tSQLState: SQL_STATE_MOCK\n"
+                                  + "\tErrorCode: 52000\n"
+                                  + "----------- END   trace SQL state -------------\n");
+    }
+
+
+    @Test
+    public void test_logNoErrorCode() throws Exception {
+        JdbcLogUtil.traceWarningsAndError(logger,
+                                          new SQLException("La raison c'est que ca va pas trop", "SQL_STATE_MOCK"));
+        verifyLogger(Level.TRACE, "\n----------- BEGIN trace SQL state -------------\n"
+                                  + "- ERROR : La raison c'est que ca va pas trop\n"
+                                  + "\tSQLState: SQL_STATE_MOCK\n"
+                                  + "\tErrorCode: 0\n"
+                                  + "----------- END   trace SQL state -------------\n");
+    }
+
+
+    private void verifyLogger(Level logLevel, String message) {
+        verify(appender).doAppend(arguments.capture());
+        assertThat(arguments.getValue().getLevel(), is(logLevel));
+        assertThat((String)arguments.getValue().getMessage(), is(message));
+    }
+}


### PR DESCRIPTION
## Context

We needed to log jdbc errors and warnings when an `SQLException` is thrown.
## Description

Add an utility class to log jdbc errors and warnings.
