### PR TITLE
Add the possibility to configure the hsqldb server host and port

### DIFF
--- a/codjo-database-hsqldb/src/main/java/net/codjo/database/hsqldb/impl/helper/HsqldbDatabaseHelper.java
+++ b/codjo-database-hsqldb/src/main/java/net/codjo/database/hsqldb/impl/helper/HsqldbDatabaseHelper.java
@@ -1,12 +1,11 @@
 package net.codjo.database.hsqldb.impl.helper;
-import net.codjo.database.common.api.ConnectionMetadata;
-import net.codjo.database.common.api.DatabaseQueryHelper;
-import net.codjo.database.common.api.ObjectType;
-import net.codjo.database.common.api.structure.SqlTable;
-import net.codjo.database.common.impl.helper.AbstractDatabaseHelper;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import net.codjo.database.common.api.ConnectionMetadata;
+import net.codjo.database.common.api.DatabaseQueryHelper;
+import net.codjo.database.common.api.structure.SqlTable;
+import net.codjo.database.common.impl.helper.AbstractDatabaseHelper;
 public class HsqldbDatabaseHelper extends AbstractDatabaseHelper {
 
     public HsqldbDatabaseHelper(DatabaseQueryHelper queryHelper) {
@@ -15,7 +14,20 @@ public class HsqldbDatabaseHelper extends AbstractDatabaseHelper {
 
 
     public String getConnectionUrl(ConnectionMetadata connectionMetadata) {
-        return "jdbc:hsqldb:.";
+        StringBuilder hostname = new StringBuilder(connectionMetadata.getHostname());
+        if (hostname.length() == 0) {
+            return "jdbc:hsqldb:.";
+        }
+        else {
+            String port = connectionMetadata.getPort();
+            if (!"".equals(port)) {
+                hostname.append(":").append(port);
+            }
+            if (!"".equals(connectionMetadata.getBase())) {
+                hostname.append("/").append(connectionMetadata.getBase());
+            }
+            return "jdbc:hsqldb:hsql://" + hostname.toString();
+        }
     }
 
 
@@ -41,7 +53,8 @@ public class HsqldbDatabaseHelper extends AbstractDatabaseHelper {
         Statement s = connection.createStatement();
         try {
             s.executeUpdate("GRANT " + groupName + " TO " + userName);
-        } finally {
+        }
+        finally {
             s.close();
         }
     }
@@ -51,7 +64,8 @@ public class HsqldbDatabaseHelper extends AbstractDatabaseHelper {
         Statement s = connection.createStatement();
         try {
             s.executeUpdate("DROP SCHEMA PUBLIC CASCADE");
-        } finally {
+        }
+        finally {
             s.close();
         }
 /*
@@ -64,6 +78,7 @@ public class HsqldbDatabaseHelper extends AbstractDatabaseHelper {
         dropAllObjects(connection, ObjectType.TRIGGER);
 */
     }
+
 
     @Override
     public void setIdentityInsert(Connection connection,

--- a/codjo-database-hsqldb/src/test/java/net/codjo/database/hsqldb/impl/helper/HsqldbDatabaseHelperTest.java
+++ b/codjo-database-hsqldb/src/test/java/net/codjo/database/hsqldb/impl/helper/HsqldbDatabaseHelperTest.java
@@ -1,21 +1,20 @@
 package net.codjo.database.hsqldb.impl.helper;
-import java.lang.Thread.State;
+import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Properties;
 import junit.framework.AssertionFailedError;
 import net.codjo.database.common.api.ConnectionMetadata;
 import net.codjo.database.common.api.DatabaseHelper;
-import static net.codjo.database.common.api.structure.SqlConstraint.foreignKey;
 import net.codjo.database.common.api.structure.SqlTable;
-import static net.codjo.database.common.api.structure.SqlTable.table;
 import net.codjo.database.common.impl.helper.AbstractDatabaseHelperTest;
 import net.codjo.database.hsqldb.impl.query.HsqldbDatabaseQueryHelper;
-import java.sql.SQLException;
-import java.util.Properties;
+import org.junit.Test;
+
+import static net.codjo.database.common.api.structure.SqlConstraint.foreignKey;
+import static net.codjo.database.common.api.structure.SqlTable.table;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
-
-import org.junit.Test;
 public class HsqldbDatabaseHelperTest extends AbstractDatabaseHelperTest {
 
     @Override
@@ -116,7 +115,8 @@ public class HsqldbDatabaseHelperTest extends AbstractDatabaseHelperTest {
             for (String role : roles) {
                 s.executeUpdate("CREATE ROLE " + role);
             }
-        } finally {
+        }
+        finally {
             s.close();
         }
         databaseHelper.changeUserGroup(jdbcFixture.getConnection(), user, users);
@@ -149,6 +149,7 @@ public class HsqldbDatabaseHelperTest extends AbstractDatabaseHelperTest {
         }
     }
 
+
     @Override
     protected void assertLibraryConnectionMetadata(ConnectionMetadata connectionMetadata) {
         assertEquals("", connectionMetadata.getHostname());
@@ -158,5 +159,23 @@ public class HsqldbDatabaseHelperTest extends AbstractDatabaseHelperTest {
         assertEquals("", connectionMetadata.getCatalog());
         assertNull(connectionMetadata.getCharset());
         assertNull(connectionMetadata.getSchema());
+    }
+
+
+    @Test
+    public void test_buildDefaultConnection() throws Exception {
+        final Properties connectionProperties = getConnectionProperties();
+        assertEquals("jdbc:hsqldb:.", databaseHelper.getConnectionUrl(new ConnectionMetadata(connectionProperties)));
+    }
+
+
+    @Test
+    public void test_buildConnection() throws Exception {
+        final Properties connectionProperties = getConnectionProperties();
+        connectionProperties.setProperty("database.hostname", "localhost");
+        connectionProperties.setProperty("database.port", "8792");
+        connectionProperties.setProperty("database.base", "magic");
+        assertEquals("jdbc:hsqldb:hsql://localhost:8792/magic",
+                     databaseHelper.getConnectionUrl(new ConnectionMetadata(connectionProperties)));
     }
 }


### PR DESCRIPTION
### Context

We need to be abble to use codjo-tokio on an hsqldb database.
### Description

In codjo-database, it was only possible to create a connection on a `in memory` database.
Now it is possible to configure the hsqldb connection url, by specifying the `hostname`, the `port` and the `base` name.
